### PR TITLE
Relax version requirements for BlueCryptor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
 	name: "SwiftAWSSignatureV4"
 	,dependencies:[
-	.Package(url:"https://github.com/IBM-Swift/BlueCryptor.git", Version("0.8.9"))
+	    .Package(url:"https://github.com/IBM-Swift/BlueCryptor.git", majorVersion: 0)
 	]
 )


### PR DESCRIPTION
BlueCryptor version "0.8.9" has an empty package manifest so when trying to use this package I get the error:

`Empty manifest file is not supported anymore. Use `swift package init` to autogenerate.`

Allowing the latest version of BlueCryptor to be used fixes this error.